### PR TITLE
feat : set base entity , create entity & repository

### DIFF
--- a/src/main/java/com/example/spring/rmago/config/JpaConfig.java
+++ b/src/main/java/com/example/spring/rmago/config/JpaConfig.java
@@ -1,0 +1,13 @@
+package com.example.spring.rmago.config;
+
+import com.example.spring.rmago.repository.BaseRepositoryImpl;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "com.example.spring.rmago.repository",
+        repositoryBaseClass = BaseRepositoryImpl.class
+)
+public class JpaConfig {
+}

--- a/src/main/java/com/example/spring/rmago/entity/BaseEntity.java
+++ b/src/main/java/com/example/spring/rmago/entity/BaseEntity.java
@@ -1,0 +1,37 @@
+package com.example.spring.rmago.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.FilterDef;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@FilterDef(name = "deletedFilter", defaultCondition = "delete_flag = 'N'")
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    protected LocalDateTime modifiedAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    protected String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "modified_by")
+    protected String modifiedBy;
+}

--- a/src/main/java/com/example/spring/rmago/entity/Customer.java
+++ b/src/main/java/com/example/spring/rmago/entity/Customer.java
@@ -1,0 +1,37 @@
+package com.example.spring.rmago.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Filter(name = "deletedFilter")
+public class Customer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id")
+    private String kakaoId;
+
+    private String nickname;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    private String email;
+
+    private String gender;
+
+    private LocalDate birth;
+
+    @Column(name = "delete_flag")
+    private String deleteFlag = "N";
+}
+

--- a/src/main/java/com/example/spring/rmago/entity/Place.java
+++ b/src/main/java/com/example/spring/rmago/entity/Place.java
@@ -1,0 +1,31 @@
+package com.example.spring.rmago.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+
+@Entity
+@Filter(name = "deletedFilter")
+@Getter
+@Setter
+public class Place extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String category;
+
+    @Column(name = "place_image_url")
+    private String placeImageUrl;
+
+    private Double lat;
+    private Double lng;
+
+    @Column(name = "delete_flag")
+    private String deleteFlag = "N";
+
+    private String address;
+    private String description;
+}

--- a/src/main/java/com/example/spring/rmago/entity/Recommendation.java
+++ b/src/main/java/com/example/spring/rmago/entity/Recommendation.java
@@ -1,0 +1,35 @@
+package com.example.spring.rmago.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+
+@Entity
+@Filter(name = "deletedFilter")
+@Getter
+@Setter
+public class Recommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "search_log_id")
+    private SearchLog searchLog;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    private Double distance;
+
+    @Column(name = "estimated_fare")
+    private Integer estimatedFare;
+
+    @Column(name = "delete_flag")
+    private String deleteFlag = "N";
+}
+

--- a/src/main/java/com/example/spring/rmago/entity/SearchLog.java
+++ b/src/main/java/com/example/spring/rmago/entity/SearchLog.java
@@ -1,0 +1,37 @@
+package com.example.spring.rmago.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+
+@Entity
+@Table(name = "search_log")
+@Filter(name = "deletedFilter")
+@Getter
+@Setter
+public class SearchLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @Column(name = "input_amount")
+    private Integer inputAmount;
+
+    @Column(name = "search_lat")
+    private Double searchLat;
+
+    @Column(name = "search_lng")
+    private Double searchLng;
+
+    @Column(name = "result_count")
+    private Integer resultCount;
+
+    @Column(name = "delete_flag")
+    private String deleteFlag = "N";
+}

--- a/src/main/java/com/example/spring/rmago/repository/BaseRepository.java
+++ b/src/main/java/com/example/spring/rmago/repository/BaseRepository.java
@@ -1,0 +1,9 @@
+package com.example.spring.rmago.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface BaseRepository<T, ID> extends JpaRepository<T, ID> {
+}
+

--- a/src/main/java/com/example/spring/rmago/repository/BaseRepositoryImpl.java
+++ b/src/main/java/com/example/spring/rmago/repository/BaseRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.example.spring.rmago.repository;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+
+public class BaseRepositoryImpl<T, ID> extends SimpleJpaRepository<T, ID> implements BaseRepository<T, ID> {
+
+    private final EntityManager entityManager;
+
+    // 각 레파지토리에서 findAll() 같은 기본 메서드 호출만으로도 soft-delete 필터가 자동 적용됨
+    public BaseRepositoryImpl(JpaEntityInformation<T, ?> entityInformation, EntityManager em) {
+        super(entityInformation, em);
+        this.entityManager = em;
+
+        // deletedFilter 자동 활성화
+        Session session = em.unwrap(Session.class);
+        session.enableFilter("deletedFilter");
+    }
+}
+

--- a/src/main/java/com/example/spring/rmago/repository/PlaceRepository.java
+++ b/src/main/java/com/example/spring/rmago/repository/PlaceRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring.rmago.repository;
+
+import com.example.spring.rmago.entity.Place;
+
+public interface PlaceRepository extends BaseRepository<Place, Long> {
+}
+

--- a/src/main/java/com/example/spring/rmago/repository/RecommendationRepository.java
+++ b/src/main/java/com/example/spring/rmago/repository/RecommendationRepository.java
@@ -1,0 +1,6 @@
+package com.example.spring.rmago.repository;
+
+import com.example.spring.rmago.entity.Recommendation;
+
+public interface RecommendationRepository extends BaseRepository<Recommendation, Long> {
+}

--- a/src/main/java/com/example/spring/rmago/repository/SearchLogRepository.java
+++ b/src/main/java/com/example/spring/rmago/repository/SearchLogRepository.java
@@ -1,0 +1,6 @@
+package com.example.spring.rmago.repository;
+
+import com.example.spring.rmago.entity.SearchLog;
+
+public interface SearchLogRepository extends BaseRepository<SearchLog, Long> {
+}

--- a/src/main/java/com/example/spring/rmago/repository/UserRepository.java
+++ b/src/main/java/com/example/spring/rmago/repository/UserRepository.java
@@ -1,0 +1,6 @@
+package com.example.spring.rmago.repository;
+
+import com.example.spring.rmago.entity.Customer;
+
+public interface UserRepository extends BaseRepository<Customer, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,16 @@
 spring:
   application:
     name: RMaGo
+  datasource:
+    url: jdbc:postgresql://localhost:5432/rmago
+    username: postgres
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # 개발 중에는 update, 운영에선 validate or none 권장
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true


### PR DESCRIPTION
**JPA Auditing**
엔티티의 생성/수정 시점을 자동으로 기록해주는 기능.
즉, 다음과 같은 필드를 직접 set 하지 않아도 JPA가 자동으로 채워줌
- createdAt (생성일)
- createdBy (생성자)
- modifiedAt (수정일)
- modifiedBy (수정자)

new Entity()할 때마다 createdAt = LocalDateTime.now() 이런 코드 반복할 필요 없음
실수 방지: 깜빡하고 날짜 안 넣는 실수를 막아줌
@CreatedDate, @LastModifiedDate만 써도 자동 기록됨


BaseEntityImpl : 각 레파지토리에서 findAll() 같은 기본 메서드 호출만으로도 soft-delete 필터가 자동 적용됨

**User 테이블 이름을 Customer로 수정! **
-> User 예약어임

Todo -> .env에 포스트그레 정보 저장해서 가져오게끔 해야되고, yml 분리하는것도 고려해볼것.